### PR TITLE
Include gateway in docker-compose.yml example file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,18 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: azimutt_dev
+
+  gateway:
+    image: node:18-slim
+    container_name: azimutt-gateway
+    command: >
+      bash -c "npm i -g azimutt &&
+        azimutt gateway"
+    depends_on:
+      - database
+    # ports:
+    #   - 4177:4177
+
   backend:
     container_name: azimutt-backend
     platform: linux/amd64
@@ -24,5 +36,10 @@ services:
     environment:
       DATABASE_URL: "ecto://postgres:postgres@database/azimutt_dev" # Template : "ecto://db_user:db_password@ip_or_compose_service_name/db_name"
       SECRET_KEY_BASE: "1wOVZ9rWAqPcbVZdilZzBPLXFKNrUmLUzX0q9Z02LpOy2jVWZwa6ee4fU81tuN+W" # Can literally be anything, but generally generated randomly by tools like mix phx.gen.secret
+      GATEWAY_URL: http://gateway:4177
+      SKIP_EMAIL_CONFIRMATION: true
+      SKIP_ONBOARDING_FUNNEL: true
+      ORGANIZATION_DEFAULT_PLAN: "free"
+
 volumes:
   pg-data:


### PR DESCRIPTION
Add the `gateway` service in the docker-compose.yml. The service allows to export schemas from your database locally by connecting to it. This is needed if you are selfhosting the service.

This helps with https://github.com/azimuttapp/azimutt/issues/281

Unfortunately, the current azimutt behavior doesn't allow to run it without using `network: host`. There is a part of the code which seems to always take `localhost:4177` as the url. See comment : https://github.com/azimuttapp/azimutt/issues/281#issuecomment-2301581892

Leaving this as a draft for now as of today the docker compose process won't work as expected. But it should be easy to fix by changing a bit the logic and always follow configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `gateway` service to enhance application functionality.
	- Added several environment variables to the backend service for improved configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->