### PR TITLE
Fix JS build to use AML in CLI

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -28,6 +28,7 @@
     "dry-publish": "pnpm run build && pnpm test && pnpm pack"
   },
   "dependencies": {
+    "@azimutt/aml": "workspace:^",
     "@azimutt/gateway": "workspace:^",
     "@azimutt/models": "workspace:^",
     "@azimutt/utils": "workspace:^",

--- a/cli/src/convert.ts
+++ b/cli/src/convert.ts
@@ -8,7 +8,7 @@ import {
     ParserResult,
     TokenEditor
 } from "@azimutt/models";
-// import {generateAml, parseAml} from "@azimutt/aml";
+import {generateAml, parseAml} from "@azimutt/aml";
 import {track} from "@azimutt/gateway";
 import {fileRead, fileWrite} from "./utils/file.js";
 import {logger} from "./utils/logger.js";
@@ -41,14 +41,33 @@ export async function convertFile(path: string, opts: Opts): Promise<void> {
     logger.log(`Done 👍️\n`)
 }
 
+// try it with: `npm run exec -- convert test.aml --from aml --to json --out test.aml.json`
 function parseDialect(dialect: string, content: string): ParserResult<Database> {
-    if (dialect === 'aml') return ParserResult.failure([{message: 'AML parser not available', kind: 'NotImplemented', level: 'error', offset: {start: 0, end: 0}, position: {start: {line: 0, column: 0}, end: {line: 0, column: 0}}}]) // parseAml(content)
+    /* FIXME: @azimutt/aml is using ESM to be bundled with Rollup, but this produce and error here:
+node:internal/modules/esm/resolve:257
+    throw new ERR_MODULE_NOT_FOUND(
+          ^
+
+Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/node_modules/.pnpm/@azimutt+aml@0.1.10/node_modules/@azimutt/aml/out/amlAst' imported from /node_modules/.pnpm/@azimutt+aml@0.1.10/node_modules/@azimutt/aml/out/index.js
+    at finalizeResolution (node:internal/modules/esm/resolve:257:11)
+    at moduleResolve (node:internal/modules/esm/resolve:913:10)
+    at defaultResolve (node:internal/modules/esm/resolve:1037:11)
+    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:650:12)
+    at #cachedDefaultResolve (node:internal/modules/esm/loader:599:25)
+    at ModuleLoader.resolve (node:internal/modules/esm/loader:582:38)
+    at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:241:38)
+    at ModuleJob._link (node:internal/modules/esm/module_job:132:49) {
+  code: 'ERR_MODULE_NOT_FOUND',
+  url: 'file:///node_modules/.pnpm/@azimutt+aml@0.1.10/node_modules/@azimutt/aml/out/amlAst'
+}
+     */
+    if (dialect === 'aml') return ParserResult.failure([{message: 'AML parser not available', kind: 'NotImplemented', level: 'error', offset: {start: 0, end: 0}, position: {start: {line: 0, column: 0}, end: {line: 0, column: 0}}}]) // FIXME: return parseAml(content)
     if (dialect === 'json') return parseJsonDatabase(content)
     return ParserResult.failure([parserError(`Can't parse ${dialect} dialect`, 'BadArgument')])
 }
 
 function generateDialect(dialect: string, db: Database): Result<string, string> {
-    if (dialect === 'aml') return Result.failure('AML generator not available') // Result.success(generateAml(db))
+    if (dialect === 'aml') return Result.failure('AML generator not available') // FIXME: return Result.success(generateAml(db))
     if (dialect === 'json') return Result.success(generateJsonDatabase(db))
     return Result.failure(`Can't generate ${dialect} dialect`)
 }

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -82,6 +82,7 @@ program.command('convert')
     .requiredOption('-f, --from <from>', 'The dialect of the file to convert from')
     .requiredOption('-t, --to <to>', 'The dialect to convert to')
     .option('-o, --out <out>', 'The file to write')
+    .option('--debug', 'Add debug logs and show the full stacktrace instead of a shorter error')
     .action((path, args) => exec(convertFile(path, args), args))
 
 program.command('diff')

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -6,7 +6,6 @@
     "target": "ES2021",
     "rootDir": "./src",
     "outDir": "./out",
-    "types": ["node"],
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "sourceMap": true,

--- a/extensions/desktop/package.json
+++ b/extensions/desktop/package.json
@@ -9,6 +9,7 @@
     "erd",
     "database tool"
   ],
+  "type": "commonjs",
   "main": ".webpack/main",
   "scripts": {
     "start": "electron-forge start",

--- a/extensions/vscode-aml/package.json
+++ b/extensions/vscode-aml/package.json
@@ -21,10 +21,11 @@
     "Visualization",
     "Snippets"
   ],
+  "type": "commonjs",
+  "browser": "./dist/web/extension.js",
   "engines": {
     "vscode": "^1.95.0"
   },
-  "browser": "./dist/web/extension.js",
   "activationEvents": [
     "onLanguage:aml",
     "onCommand:aml.new",

--- a/extensions/vscode-aml/src/web/convert.ts
+++ b/extensions/vscode-aml/src/web/convert.ts
@@ -1,4 +1,5 @@
-import vscode, {TextEditor} from "vscode";
+import * as vscode from "vscode";
+import {TextEditor} from "vscode";
 import {
     generateAml,
     generateDot,

--- a/extensions/vscode-aml/src/web/diagnostics.ts
+++ b/extensions/vscode-aml/src/web/diagnostics.ts
@@ -1,4 +1,5 @@
-import vscode, {
+import * as vscode from "vscode";
+import {
     Diagnostic,
     DiagnosticCollection,
     DiagnosticSeverity,

--- a/extensions/vscode-aml/src/web/extension.ts
+++ b/extensions/vscode-aml/src/web/extension.ts
@@ -1,4 +1,5 @@
-import vscode, {ExtensionContext, TextEditor} from "vscode";
+import * as vscode from "vscode";
+import {ExtensionContext, TextEditor} from "vscode";
 import {newAml} from "./new";
 import {convertAmlToDialect, convertJsonToAml, convertSqlToAml} from "./convert";
 import {openInAzimutt} from "./open";

--- a/extensions/vscode-aml/src/web/new.ts
+++ b/extensions/vscode-aml/src/web/new.ts
@@ -1,4 +1,4 @@
-import vscode from "vscode";
+import * as vscode from "vscode";
 import {openFile} from "./utils";
 
 const amlLib = import("@azimutt/aml");

--- a/extensions/vscode-aml/src/web/open.ts
+++ b/extensions/vscode-aml/src/web/open.ts
@@ -1,4 +1,5 @@
-import vscode, {TextEditor, Uri} from "vscode";
+import * as vscode from "vscode";
+import {TextEditor, Uri} from "vscode";
 
 export async function openInAzimutt(editor: TextEditor): Promise<void> {
     if (editor.document.languageId !== 'aml') {

--- a/extensions/vscode-aml/src/web/preview.ts
+++ b/extensions/vscode-aml/src/web/preview.ts
@@ -1,4 +1,5 @@
-import vscode, {
+import * as vscode from "vscode";
+import {
     ExtensionContext,
     TextDocument,
     TextDocumentChangeEvent,

--- a/extensions/vscode-aml/src/web/utils.ts
+++ b/extensions/vscode-aml/src/web/utils.ts
@@ -1,4 +1,5 @@
-import vscode, {Position, Range, TextDocument} from "vscode";
+import * as vscode from "vscode";
+import {Position, Range, TextDocument} from "vscode";
 import {Database, EditorPosition, ParserError, ParserErrorLevel, ParserResult, TokenEditor} from "@azimutt/models";
 
 export async function openFileResult(res: ParserResult<Database>, transform: (db: Database) => Promise<{lang: string, content: string}>): Promise<TextDocument | undefined> {

--- a/extensions/vscode-aml/tsconfig.json
+++ b/extensions/vscode-aml/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
-    "module": "Node16",
-    "lib": ["ES2020", "WebWorker"],
-    "target": "ES2020",
-    "rootDir": "src",
-    "outDir": "dist",
+    "module": "commonjs",
+    "lib": ["ES2021", "WebWorker"],
+    "target": "ES2021",
+    "rootDir": "./src",
+    "outDir": "./dist",
     "sourceMap": true,
     "strict": true,
     "skipLibCheck": true

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -12,6 +12,7 @@
     "erd",
     "entity-relationship diagram"
   ],
+  "type": "commonjs",
   "main": "./out/index.js",
   "types": "./out/index.d.ts",
   "scripts": {

--- a/libs/aml/rollup.config.ts
+++ b/libs/aml/rollup.config.ts
@@ -8,10 +8,6 @@ import resolve from "@rollup/plugin-node-resolve"
 export default {
     input: 'src/index.ts',
     output: [{
-        file: 'out/bundle.js',
-        format: 'cjs',
-        sourcemap: true,
-    }, {
         file: 'out/bundle.min.js',
         format: 'iife',
         sourcemap: true,

--- a/libs/connector-bigquery/package.json
+++ b/libs/connector-bigquery/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "homepage": "https://azimutt.app",
   "keywords": [],
+  "type": "commonjs",
   "main": "./out/index.js",
   "types": "./out/index.d.ts",
   "scripts": {

--- a/libs/connector-couchbase/package.json
+++ b/libs/connector-couchbase/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "homepage": "https://azimutt.app",
   "keywords": [],
+  "type": "commonjs",
   "main": "./out/index.js",
   "types": "./out/index.d.ts",
   "scripts": {

--- a/libs/connector-mariadb/package.json
+++ b/libs/connector-mariadb/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "homepage": "https://azimutt.app",
   "keywords": [],
+  "type": "commonjs",
   "main": "./out/index.js",
   "types": "./out/index.d.ts",
   "scripts": {

--- a/libs/connector-mongodb/package.json
+++ b/libs/connector-mongodb/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "homepage": "https://azimutt.app",
   "keywords": [],
+  "type": "commonjs",
   "main": "./out/index.js",
   "types": "./out/index.d.ts",
   "scripts": {

--- a/libs/connector-mysql/package.json
+++ b/libs/connector-mysql/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "homepage": "https://azimutt.app",
   "keywords": [],
+  "type": "commonjs",
   "main": "./out/index.js",
   "types": "./out/index.d.ts",
   "scripts": {

--- a/libs/connector-oracle/package.json
+++ b/libs/connector-oracle/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "homepage": "https://azimutt.app",
   "keywords": [],
+  "type": "commonjs",
   "main": "./out/index.js",
   "types": "./out/index.d.ts",
   "scripts": {

--- a/libs/connector-postgres/package.json
+++ b/libs/connector-postgres/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "homepage": "https://azimutt.app",
   "keywords": [],
+  "type": "commonjs",
   "main": "./out/index.js",
   "types": "./out/index.d.ts",
   "scripts": {

--- a/libs/connector-snowflake/package.json
+++ b/libs/connector-snowflake/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "homepage": "https://azimutt.app",
   "keywords": [],
+  "type": "commonjs",
   "main": "./out/index.js",
   "types": "./out/index.d.ts",
   "scripts": {

--- a/libs/connector-sqlserver/package.json
+++ b/libs/connector-sqlserver/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "homepage": "https://azimutt.app",
   "keywords": [],
+  "type": "commonjs",
   "main": "./out/index.js",
   "types": "./out/index.d.ts",
   "scripts": {

--- a/libs/models/package.json
+++ b/libs/models/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "homepage": "https://azimutt.app",
   "keywords": [],
+  "type": "commonjs",
   "main": "./out/index.js",
   "types": "./out/index.d.ts",
   "scripts": {

--- a/libs/parser-dbml/rollup.config.ts
+++ b/libs/parser-dbml/rollup.config.ts
@@ -8,10 +8,6 @@ import resolve from "@rollup/plugin-node-resolve"
 export default {
     input: 'src/index.ts',
     output: [{
-        file: 'out/bundle.js',
-        format: 'cjs',
-        sourcemap: true,
-    }, {
         file: 'out/bundle.min.js',
         format: 'iife',
         sourcemap: true,

--- a/libs/parser-prisma/rollup.config.ts
+++ b/libs/parser-prisma/rollup.config.ts
@@ -8,10 +8,6 @@ import resolve from "@rollup/plugin-node-resolve"
 export default {
     input: 'src/index.ts',
     output: [{
-        file: 'out/bundle.js',
-        format: 'cjs',
-        sourcemap: true,
-    }, {
         file: 'out/bundle.min.js',
         format: 'iife',
         sourcemap: true,

--- a/libs/parser-sql/rollup.config.ts
+++ b/libs/parser-sql/rollup.config.ts
@@ -8,10 +8,6 @@ import resolve from "@rollup/plugin-node-resolve"
 export default {
     input: 'src/index.ts',
     output: [{
-        file: 'out/bundle.js',
-        format: 'cjs',
-        sourcemap: true,
-    }, {
         file: 'out/bundle.min.js',
         format: 'iife',
         sourcemap: true,

--- a/libs/utils/package.json
+++ b/libs/utils/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "homepage": "https://azimutt.app",
   "keywords": [],
+  "type": "commonjs",
   "main": "./out/index.js",
   "types": "./out/index.d.ts",
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,9 @@ importers:
 
   cli:
     dependencies:
+      '@azimutt/aml':
+        specifier: workspace:^
+        version: link:../libs/aml
       '@azimutt/gateway':
         specifier: workspace:^
         version: link:../gateway


### PR DESCRIPTION
**Problem**: can't use `@azimutt/aml` lib in `azimutt` CLI

- `@azimutt/aml` lib is using ESM to be packaged a IIFE with Rollup
- `azimutt` CLI is also ESM

Error:
```
node:internal/modules/esm/resolve:257
    throw new ERR_MODULE_NOT_FOUND(
          ^

Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/node_modules/.pnpm/@azimutt+aml@0.1.10/node_modules/@azimutt/aml/out/amlAst' imported from /node_modules/.pnpm/@azimutt+aml@0.1.10/node_modules/@azimutt/aml/out/index.js
    at finalizeResolution (node:internal/modules/esm/resolve:257:11)
    at moduleResolve (node:internal/modules/esm/resolve:913:10)
    at defaultResolve (node:internal/modules/esm/resolve:1037:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:650:12)
    at #cachedDefaultResolve (node:internal/modules/esm/loader:599:25)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:582:38)
    at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:241:38)
    at ModuleJob._link (node:internal/modules/esm/module_job:132:49) {
  code: 'ERR_MODULE_NOT_FOUND',
  url: 'file:///node_modules/.pnpm/@azimutt+aml@0.1.10/node_modules/@azimutt/aml/out/amlAst'
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added `--debug` option for `convert`, `diff`, and `clustering` commands to enhance error visibility.
  - Introduced dependency on `@azimutt/aml` for improved AML parsing and generation capabilities.

- **Bug Fixes**
  - Improved error handling for AML parsing and generation, acknowledging current limitations.

- **Documentation**
  - Updated package.json files across multiple libraries to specify `"type": "commonjs"`.

- **Chores**
  - Removed CommonJS output configuration from Rollup settings in various libraries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->